### PR TITLE
refactor: compose now installed from repo, w. remove for engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,26 +9,49 @@ All values are optional unless otherwise marked as required
 
 ```yaml
 docker:
-  version: string                     Indicates the version to install. If empty, latest will be used.
-  remove: bool                        Indicates if `Docker` should be remove from the system. Default false.
+  version: [string]                     Indicates the version to install. If empty, latest will be used. Can be set to 'latest' for the latest version.
+  remove: [bool]                        Indicates if `Docker` should be remove from the system. Default false.
   compose:
-    version: string                   [Required] Indicates the version of `Docker Compose` to install.
+    version: [string]                   [Required] Indicates the version of `Docker Compose` to install. Can be set to 'latest' for the latest version.
+    remove: [bool]
     compositions:
-      - name: string                  [Required]	Used as project directory name if `destination` is not found.
-        source: string                [Required] The local path to the `Docker Compose` project.
-        destination: string           The remote location where the project directory should be.
-        user: string                  The remote user who should own the project directory, else `root`.
-        group: string                 The remote group who should own the project directory, else `root`.
+      - name: [string]                  [Required]	Used as project directory name if `destination` is not found.
+        source: [string]                [Required] The local path to the `Docker Compose` project.
+        destination: [string]           The remote location where the project directory should be.
+        user: [string]                  The remote user who should own the project directory, else `root`.
+        group: [string]                 The remote group who should own the project directory, else `root`.
         secrets:
-          - name: string              [Required] The name of the file containing the secret at `<project-dir>/secrets/name`.
-            value: string | number    The value to set in the secret file. Mutually exlusive with `variable`.
-            variable: string          The variable holding the value to set in the secret file. Mutually exlusive with `value`.
-            remove: bool              Indicates that this named secret should be removed.
+          - name: [string]              [Required] The name of the file containing the secret at `<project-dir>/secrets/name`.
+            value: [string | number]    The value to set in the secret file. Mutually exlusive with `variable`.
+            variable: [string]          The variable holding the value to set in the secret file. Mutually exlusive with `value`.
+            remove: [bool]              Indicates that this named secret should be removed.
         environment:
-          - name: string              [Required] The name of the variable.
-            value: string | number    The value to set the variable to. Mutually exlusive with `variable`.
-            variable: string          The variable holding the value to set the env variable to. Mutually exlusive with `value`.
-            remove: true              Indicates that this named variable should be removed.
+          - name: [string]              [Required] The name of the variable.
+            value: [string | number]    The value to set the variable to. Mutually exlusive with `variable`.
+            variable: [string]          The variable holding the value to set the env variable to. Mutually exlusive with `value`.
+            remove: [bool]              Indicates that this named variable should be removed.
+```
+
+#### Example
+
+```yaml
+docker:
+  version: "5:27.4.1-1~ubuntu.22.04~jammy"
+  compose:
+    version: "2.32.1-1~ubuntu.22.04~jammy"
+    compositions:
+      - name: "example-project"
+        source: "/docker/example-project/docker-compose.yml"
+        secrets:
+          - name: "db-user"
+            variable: "secret-db-user"
+          - name: "db-password"
+            variable: "secret-db-password"
+        environment:
+          - name: "db-port" # Remove previously set port
+            remove: true
+          - name: "db-port" # Set new port information
+            value: 1234
 ```
 
 ### Compositions

--- a/files/assertions/criteria/docker-criteria.json
+++ b/files/assertions/criteria/docker-criteria.json
@@ -21,6 +21,10 @@
                 {
                     "$ref": "#/definitions/non-empty-string"
                 },
+                "remove":
+                {
+                    "type": "boolean"
+                },
                 "compositions":
                 {
                     "type": "array",
@@ -173,11 +177,7 @@
                         ]
                     }
                 }
-            },
-            "required":
-            [
-                "version"
-            ]
+            }
         }
     },
     "definitions":

--- a/tasks/install/debian.yml
+++ b/tasks/install/debian.yml
@@ -1,11 +1,11 @@
 # -----------------------------------------------------------------------------
 #
 # This file contains tasks related to configuring installation of Docker
-# for an Debian based system.
+# and relevant plugins for an Debian based system.
 #
 # -----------------------------------------------------------------------------
 
-- name: docker | debian | add repository
+- name: "Docker | Debian | Add official repository"
   ansible.builtin.deb822_repository:
     name: docker
     types: [deb]
@@ -13,21 +13,30 @@
     signed_by: "https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg"
     suites: ["{{ ansible_distribution_release }}"]
     components: [stable]
-    state: present
+    state: "{{ 'absent' if docker.remove is defined and docker.remove else 'present' }}"
     enabled: true
   register: docker_repo_state
 
-- name: docker | debian | update apt
+- name: "Docker | Debian | Update apt"
   ansible.builtin.apt:
     update_cache: yes
   when:
     - docker_repo_state.changed
 
-- name: docker | apt | set package name
-  ansible.builtin.set_fact:
-    docker_package_name: "{{ 'docker-ce=' + docker.version if docker.version is defined else 'docker-ce' }}"
-
-- name: docker | apt | install docker-ce
+- name: "Docker | Debian | Manage 'docker-ce' package"
   ansible.builtin.apt:
-    name: "{{ docker_package_name }}"
-    state: "{{ 'absent' if docker.remove is defined and docker.remove else 'present' if docker.version is defined else 'latest' }}"
+    name: "{{ 'docker-ce=' + docker.version if docker.version is defined and docker.version != 'latest' else 'docker-ce' }}"
+    state: >-
+      {{ 'absent' if docker.remove is defined and docker.remove
+          else 'present' if docker.version is defined and docker.version != 'latest'
+          else 'latest' }}
+
+- name: "Docker | Debian | Manage 'docker-compose-plugin' package"
+  ansible.builtin.apt:
+    name: "{{ 'docker-compose-plugin=' + docker.compose.version if docker.compose.version is defined and docker.compose.version != 'latest' else 'docker-compose-plugin'}}"
+    state: >-
+      {{ 'absent' if docker.compose.remove is defined and docker.remove
+          else 'present' if docker.compose.version is defined and docker.compose.version != 'latest'
+          else 'latest' }}
+  when:
+    - docker.compose is defined

--- a/tasks/install/main.yml
+++ b/tasks/install/main.yml
@@ -4,15 +4,7 @@
 #
 # -----------------------------------------------------------------------------
 
-- name: docker | install | install docker debian
+- name: "Docker | Install | Install Docker for Debian systems"
   ansible.builtin.include_tasks: debian.yml
   when:
     - ansible_distribution in ["Ubuntu", "Debian"]
-
-- name: docker | compose | install docker compose
-  ansible.builtin.get_url:
-    url: "https://github.com/docker/compose/releases/download/{{ docker.compose.version }}/docker-compose-linux-x86_64"
-    dest: "/usr/local/bin/docker-compose"
-    mode: '0755'
-  when:
-    - docker.compose is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,13 +3,13 @@
     data: "{{ docker }}"
     criteria: "{{ lookup('file', 'assertions/criteria/docker-criteria.json') | from_json }}"
     engine: ansible.utils.jsonschema
-  when:
-    - docker is defined
+  run_once: yes
+  delegate_to: localhost
 
-- name: docker | install
+- name: "Docker | Install"
   ansible.builtin.include_tasks: install/main.yml
 
-- name: docker | compose
+- name: "Docker | Compose | Configure"
   ansible.builtin.include_tasks: compose/main.yml
   when:
     - docker.compose is defined


### PR DESCRIPTION
- Docker compose installation for Debian systems now uses official Debian repository rather than Github repository.
- Docker remove field added to compose schema and implemented in installation task.
- Task labelling improved.