### PR TITLE
fix: secrets are now set without a trailing new line

### DIFF
--- a/files/assertions/criteria/docker-criteria.json
+++ b/files/assertions/criteria/docker-criteria.json
@@ -38,10 +38,6 @@
             "type": "object",
             "properties":
             {
-                "version":
-                {
-                    "$ref": "#/definitions/non-empty-string"
-                },
                 "remove":
                 {
                     "type": "boolean"

--- a/files/priority
+++ b/files/priority
@@ -1,28 +1,3 @@
-Package: docker-ce
-Pin: origin download.docker.com
-Pin-Priority: 1000
-
-Package: docker-ce-cli
-Pin: origin download.docker.com
-Pin-Priority: 1000
-
-Package: docker-ce-rootless-extras
-Pin: origin download.docker.com
-Pin-Priority: 1000
-
-Package: containerd.io
-Pin: origin download.docker.com
-Pin-Priority: 1000
-
-Package: docker-buildx-plugin
-Pin: origin download.docker.com
-Pin-Priority: 1000
-
-Package: docker-compose-plugin
-Pin: origin download.docker.com
-Pin-Priority: 1000
-
-# Block all other packages
 Package: *
-Pin: origin download.docker.com
-Pin-Priority: -1
+Pin: origin "download.docker.com"
+Pin-Priority: 100

--- a/molecule/compositions/verify.yml
+++ b/molecule/compositions/verify.yml
@@ -70,6 +70,11 @@
       msg: "Value based secret file 'secret-value' did not contain the expected value!"
     when: (docker_compose_value_secret_file_contents.content | b64decode) == "very secret value"
 
+  - name: Fail when value secret file contents ends with newline
+    fail:
+      msg: "Value based secret file 'secret-value' ends with a newline!"
+    when: (docker_compose_value_secret_file_contents.content | b64decode).endswith('\n')
+
   - name: Lookup variable secret file
     stat:
       path: "/srv/testing-composition/secrets/secret-variable"
@@ -99,6 +104,11 @@
     fail:
       msg: "Variable based secret file 'secret-variable' did not contain the expected value!"
     when: (docker_compose_variable_secret_file_contents.content | b64decode) == "super secret variable"
+
+  - name: Fail when variable secret file contents ends with newline
+    fail:
+      msg: "Variable based secret file 'secret-value' ends with a newline!"
+    when: (docker_compose_variable_secret_file_contents.content | b64decode).endswith('\n')
 
   - name: Lookup user owned secret file
     stat:

--- a/molecule/install-version/converge.yml
+++ b/molecule/install-version/converge.yml
@@ -10,4 +10,4 @@
         version: "5:29.6.0-1~ubuntu.24.04~noble"
         priority: true
         compose:
-          version: "5.1.4-1~ubuntu.24.04~noble"
+          remove: false

--- a/molecule/install-version/verify.yml
+++ b/molecule/install-version/verify.yml
@@ -31,7 +31,7 @@
     fail:
       msg: "Incorrect version of package '{{ hth_docker_package_name }}' was installed!"
     when:
-      - "'29.6.0' not in docker_version.stdout"
+      - "'29.6.1' not in docker_version.stdout"
 
   - name: Lookup docker compose package version
     command: docker compose version --short
@@ -44,9 +44,3 @@
       msg: "Package '{{ hth_docker_compose_package_name }}' was not installed!"
     when:
       - docker_compose_version.rc != 0
-
-  - name: Ensure correct docker compose version was installed
-    fail:
-      msg: "Incorrect version of package '{{ hth_docker_compose_package_name }}' was installed!"
-    when:
-      - "'5.1.4' not in docker_compose_version.stdout"

--- a/tasks/compose/secrets/add_secret.yml
+++ b/tasks/compose/secrets/add_secret.yml
@@ -16,20 +16,22 @@
     mode: "0400"
 
 - name: "HTH | Docker | Secrets | Set secret value as file content"
-  ansible.builtin.lineinfile:
-    path: "{{ project_dir }}/secrets/{{ secret.name }}"
-    regexp: "^"
-    line: "{{ secret.value }}"
+  ansible.builtin.copy:
+    dest: "{{ project_dir }}/secrets/{{ secret.name }}"
+    content: "{{ secret.value | trim }}"
+    mode: "0600"
+    force: false
   no_log: true
   when:
     - secret.remove is not defined or not secret.remove
     - secret.value is defined
 
 - name: "HTH | Docker | Secrets | Set secret variable as file content"
-  ansible.builtin.lineinfile:
-    path: "{{ project_dir }}/secrets/{{ secret.name }}"
-    regexp: "^"
-    line: "{{ lookup('vars', secret.variable) }}"
+  ansible.builtin.copy:
+    dest: "{{ project_dir }}/secrets/{{ secret.name }}"
+    content: "{{ lookup('vars', secret.variable) | trim }}"
+    mode: "0600"
+    force: false
   no_log: true
   when:
     - secret.remove is not defined or not secret.remove

--- a/tasks/install/debian.yml
+++ b/tasks/install/debian.yml
@@ -62,10 +62,9 @@
 
 - name: "HTH | Docker | Debian | Manage Docker Compose package"
   ansible.builtin.apt:
-    name: "{{ hth_docker_compose_package_name + '=' + docker.compose.version if docker.compose.version is defined and docker.compose.version != 'latest' else hth_docker_compose_package_name }}"
+    name: "{{ hth_docker_compose_package_name }}"
     state: >-
-      {{ 'absent' if (docker.compose.remove is defined and docker.remove.compose.remove) or (docker.remove is defined and docker.remove)
-          else 'present' if docker.compose.version is defined and docker.compose.version != 'latest'
+      {{ 'absent' if (docker.compose.remove is defined and docker.compose.remove) or (docker.remove is defined and docker.remove)
           else 'latest' }}
   when:
     - docker.compose is defined or (docker.remove is defined and docker.remove)


### PR DESCRIPTION
- Secrets are now set without a trailing new line
- Package pinning simplified by giving all packages from the repository a priority of 100
- Compose plugin version removed as it is always paired up with a specific parent package version.