### PR TITLE
refactor: secrets can now be force set

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ docker:
     key:    [string]                    The path to the signing key that should be used for the Docker repository. If missing, then the repositories own remote key will be used for signing.
   priority: [bool]                      Indicates if docker related packages should be prioritized from this repository and others blocked. Defaults to false.
   compose:
-    version: [string]                   [Required] Indicates the version of `Docker Compose` to install. Can be set to 'latest' for the latest version.
     remove: [bool]
     compositions:
       - name: [string]                  [Required]	Used as project directory name if `destination` is not found.
@@ -70,6 +69,7 @@ docker:
             owner: [string]             The user that will own the file containing the secret. If not set will default to 'root'.
             group: [string]             The user group that will own the file containing the secret. If not set, will default to the same value used as the owner.
             remove: [bool]              Indicates that this named secret should be removed.
+            force:  [bool]              Indicates that this secret should always be updated. Will break idempotency. Defaults to false.
         environments:
           - mode: [string]              The access mode that the environment file will be given. Defaults to '0644'
             owner: [string]             The user that should own the .env file. If not set defaults to the composition user. If they are not set, defaults to root.
@@ -100,7 +100,6 @@ docker:
 docker:
   version: "5:27.4.1-1~ubuntu.22.04~jammy"
   compose:
-    version: "2.32.1-1~ubuntu.22.04~jammy"
     compositions:
       - name: "example-project"
         source: "/docker/example-project/docker-compose.yml"

--- a/files/assertions/criteria/docker-criteria.json
+++ b/files/assertions/criteria/docker-criteria.json
@@ -275,6 +275,11 @@
                                         "remove":
                                         {
                                             "type": "boolean"
+                                        },
+                                        "force":
+                                        {
+                                            "description": "Indicates that the secret content should always be set, even when a file with this name already exists. Breaks idempotency. Defaults to false",
+                                            "type": "boolean"
                                         }
                                     },
                                     "required":

--- a/tasks/compose/secrets/add_secret.yml
+++ b/tasks/compose/secrets/add_secret.yml
@@ -20,7 +20,7 @@
     dest: "{{ project_dir }}/secrets/{{ secret.name }}"
     content: "{{ secret.value | trim }}"
     mode: "0600"
-    force: false
+    force: secret.force | default(false)
   no_log: true
   when:
     - secret.remove is not defined or not secret.remove
@@ -31,7 +31,7 @@
     dest: "{{ project_dir }}/secrets/{{ secret.name }}"
     content: "{{ lookup('vars', secret.variable) | trim }}"
     mode: "0600"
-    force: false
+    force: secret.force | default(false)
   no_log: true
   when:
     - secret.remove is not defined or not secret.remove


### PR DESCRIPTION
Adds a force variable for secrets, allowing them to be force set each time. This comes with idempotency being broken for roles and playbooks that use it.